### PR TITLE
過去のタスク表示機能APIテスト

### DIFF
--- a/app/controllers/api/v1/draft_learns_controller.rb
+++ b/app/controllers/api/v1/draft_learns_controller.rb
@@ -31,7 +31,13 @@ class Api::V1::DraftLearnsController < ApplicationController
   end
 
   def todays_task
-    user = User.find(params[:id])
+    user = User.find_by(id:params[:id])
+   return render json: {
+      data:{
+       errors:"ユーザが存在しません。"
+      }
+     },status:401 if !user
+
     draft_learns = user.draft_learns
     # draft_learns = current_api_v1_user.draft_learns
     next_tasks=draft_learns.date_range(Time.now.beginning_of_day,Time.now.end_of_day)
@@ -48,7 +54,12 @@ class Api::V1::DraftLearnsController < ApplicationController
   end
 
   def  past_tasks
-    user = User.find(params[:id])
+    user = User.find_by(id:params[:id])
+    return render json: {
+      data:{
+       errors:"ユーザが存在しません。"
+      }
+     },status:401 if !user
     draft_learns = user.draft_learns
     previous_tasks= draft_learns.where("created_at < ?",Time.now.ago(1.days).end_of_day)
     render json: {

--- a/app/controllers/api/v1/learns_controller.rb
+++ b/app/controllers/api/v1/learns_controller.rb
@@ -30,7 +30,12 @@ class Api::V1::LearnsController < ApplicationController
   end
 
   def todays_task
-    user = User.find(params[:id])
+    user = User.find_by(params[:id])
+    return render json: {
+      data:{
+       errors:"ユーザが存在しません。"
+      }
+     },status:401 if !user
     learns=user.learns
     # # learns    =  current_api_v1_user.learns
     next_tasks =  learns.date_range(Time.now.beginning_of_day,Time.now.end_of_day)
@@ -44,8 +49,13 @@ class Api::V1::LearnsController < ApplicationController
      },status:200
   end
 
-  def past_tasks
-    user = User.find(params[:id])
+  def  past_tasks
+    user = User.find_by(id:params[:id])
+    return render json: {
+      data:{
+       errors:"ユーザが存在しません。"
+      }
+     },status:401 if !user
     rows = params[:rows].to_i
     learns = user.learns
     cuurent_page=params[:cuurent_page].to_i
@@ -53,13 +63,15 @@ class Api::V1::LearnsController < ApplicationController
     start_range=cuurent_page-1 <=0  ? 0 : (cuurent_page-1)*rows
     previous_tasks= learns.where("created_at < ?",Time.now.ago(1.days).end_of_day)
     max_page = get_max_page(previous_tasks,rows)
-    data= data=previous_tasks.order(created_at:"DESC")[start_range..(end_range-1)]
+    data=previous_tasks.order(created_at:"DESC")[start_range..(end_range-1)]
+    message=data.nil? ?  "ページが存在しないです。": ""
     render json: {
       data:{
         previousTasks:{
           data:data,
           title: "#{Time.now.year}年#{Time.now.month}月#{Time.now.day}日の学習予定（本日）"
         },
+        message: message ,
         maxPage:max_page,
       }
      },status:200

--- a/spec/requests/draft_learns_spec.rb
+++ b/spec/requests/draft_learns_spec.rb
@@ -133,4 +133,6 @@ RSpec.describe "DraftLearns", type: :request do
         end
     end
   end
+  describe "過去のタスク" do
+  end
 end

--- a/spec/requests/draft_learns_spec.rb
+++ b/spec/requests/draft_learns_spec.rb
@@ -134,5 +134,6 @@ RSpec.describe "DraftLearns", type: :request do
     end
   end
   describe "過去のタスク" do
+
   end
 end

--- a/spec/requests/learns_spec.rb
+++ b/spec/requests/learns_spec.rb
@@ -141,4 +141,6 @@ RSpec.describe "Learns", type: :request do
         end
     end
   end
+  describe "過去のタスク" do
+  end
 end

--- a/spec/requests/learns_spec.rb
+++ b/spec/requests/learns_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
-
 RSpec.describe "Learns", type: :request do
   let(:user){FactoryBot.create(:other)}
   let(:draft_learn){FactoryBot.create(:draft_learn,user_id:user.id)}
   let(:learn){FactoryBot.build(:learn,user_id:user.id,draft_learn_id:draft_learn.id)}
+  let(:other_user){FactoryBot.create(:test_user1)}
   before do
     @params=auth_post user, api_v1_user_session_path,
     params:{
@@ -104,7 +104,6 @@ RSpec.describe "Learns", type: :request do
   end
   describe "今日のタスク" do
     describe "GET /api/v1/learns/todays_task #todays_task" do
-      let(:other_user){FactoryBot.create(:test_user1)}
       before do
         FactoryBot.create(:learn,draft_learn_id:draft_learn.id,user_id:user.id,created_at:Time.now)
         FactoryBot.create(:learn,draft_learn_id:draft_learn.id,user_id:other_user.id)
@@ -142,5 +141,180 @@ RSpec.describe "Learns", type: :request do
     end
   end
   describe "過去のタスク" do
+    describe "GET /api/v1/learns/past_tasks?id=&cuurent_page=&rows=" do
+      before "" do
+        100.times do |n|
+          FactoryBot.create(:learn,draft_learn_id:draft_learn.id,user_id:user.id,created_at:Time.now)
+          FactoryBot.create(:learn,draft_learn_id:draft_learn.id,user_id:other_user.id)
+        end
+      end
+      describe "データが降順に整列されている" do
+        it "１ページ目の最初のタスクが最後にDBに登録されていれば、降順に整列されている" do
+          travel 1.day
+          get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:1,rows:10},headers:@params[:headers])
+          res=JSON.parse(response.body)
+          last_learn=Learn.where(user_id:user.id)[-1]
+          expect(res['data']['previousTasks']['data'][0]['id']).to eq  last_learn.id
+        end
+      end
+      context "最大タスク表示数10の場合" do
+        describe "1ページ目" do
+          subject{ get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:1,rows:10},headers:@params[:headers])}
+          it "10個のタスクを取得する" do
+            travel 1.day
+            subject
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 10
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            subject
+            expect(response.status).to eq 200
+          end
+        end
+        describe "5ページ目" do
+          it "10個のタスクを取得する" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:5,rows:10},headers:@params[:headers])
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 10
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:5,rows:10},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+        end
+        describe "10ページ目" do
+          it "10個のタスクを取得する" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:10,rows:10},headers:@params[:headers])
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 10
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:10,rows:10},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+        end
+      end
+      context "最大タスク表示数20の場合" do
+        subject{ get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:1,rows:20},headers:@params[:headers])}
+        describe "1ページ目" do
+          it "20個のタスクを取得する" do
+            travel 1.day
+            subject
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 20
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            subject
+            expect(response.status).to eq 200
+          end
+        end
+        describe "2ページ目" do
+          it "20個のタスクを取得する" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:2,rows:20},headers:@params[:headers])
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 20
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:2,rows:20},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+        end
+        describe "5ページ目" do
+          it "20個のタスクを取得する" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:2,rows:20},headers:@params[:headers])
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 20
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:2,rows:20},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+        end
+      end
+      context "最大タスク表示数30の場合" do
+        subject{ get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:1,rows:30},headers:@params[:headers])}
+        describe "1ページ目" do
+          it "30個のタスクを取得する" do
+            travel 1.day
+            subject
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 30
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            subject
+            expect(response.status).to eq 200
+          end
+        end
+        describe "3ページ目" do
+          it "30個のタスクを取得する" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:3,rows:30},headers:@params[:headers])
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 30
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:3,rows:30},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+        end
+        describe "4ページ目" do
+          it "10個のタスクを取得する" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:4,rows:30},headers:@params[:headers])
+            res=JSON.parse(response.body)
+            expect(res['data']['previousTasks']['data'].size).to eq 10
+          end
+          it "ステータスコードが200が返ってくる" do
+            travel 1.day
+            get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:4,rows:30},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+        end
+      end
+      describe "存在しないページが指定された" do
+        it "タスクが存在しない(nil)" do
+          travel 1.day
+          get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:5,rows:30},headers:@params[:headers])
+          res=JSON.parse(response.body)
+          expect(res['data']['previousTasks']['data']).to be_nil
+        end
+      end
+      describe "存在しないユーザが指定された" do
+        it "ステータスコード401が返ってくる"do
+        travel 1.day
+          get(past_tasks_api_v1_learns_path,params:{id:100,cuurent_page:5,rows:30},headers:@params[:headers])
+          expect(response.status).to eq 401
+        end
+        it "エラーメッセージが返ってくる" do
+          get(past_tasks_api_v1_learns_path,params:{id:100,cuurent_page:5,rows:30},headers:@params[:headers])
+          res=JSON.parse(response.body)
+          expect(res['data']['errors']).to include("ユーザが存在しません。")
+        end
+      end
+      describe "当日のタスクは取得しない" do
+        it "データが存在しない" do
+          get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:5,rows:30},headers:@params[:headers])
+          res=JSON.parse(response.body)
+          expect(res['data']['previousTasks']['data']).to be_nil
+        end
+        it "ステータスコード200が返ってくる" do
+          get(past_tasks_api_v1_learns_path,params:{id:user.id,cuurent_page:5,rows:30},headers:@params[:headers])
+          res=JSON.parse(response.body)
+          expect(res['data']['previousTasks']['data']).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# What
・過去のタスク表示機能のAPIテストを書く
・当日を除く過去のタスクを条件によって取得する。

# Why
・1ページあたりに表示するページ数の確認(10,20,30)
・タスクが降順に整列されているか確認
・ページ数によって取得するタスクが変わるか検証。
・クエリパラメータの検証