### PR TITLE
いいね機能単体テスト

### DIFF
--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :like do
+    
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,5 +1,151 @@
 require 'rails_helper'
-
 RSpec.describe Like, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:cuurent_user){FactoryBot.create(:test_user2)}
+  let(:other_user){FactoryBot.create(:test_user1)}
+  describe "いいね機能" do
+    before do
+      [cuurent_user,other_user].each do |u|
+        5.times do |n|
+          draft_learn=DraftLearn.new({id: nil, title: "test#{n}", content: "content#{n}", subject: "test", time: 1, created_at: nil, updated_at: nil,user_id:u.id})
+          draft_learn.save!
+          learn = Learn.new({id: nil, title: "test#{n}", content: "content#{n}", subject: "", time: 1, created_at: nil, updated_at: nil,draft_learn_id:draft_learn.id,user_id:u.id})
+          subject=rand(4)
+          case subject
+            when 0
+              draft_learn.subject="プログラミング"
+              learn.subject="プログラミング"
+            when 1
+              draft_learn.subject="英語"
+              learn.subject="英語"
+            when 2
+              draft_learn.subject="資格"
+              learn.subject="資格"
+            when 3
+              draft_learn.subject="その他"
+              learn.subject="その他"
+          end
+          draft_learn.created_at=Time.new("2020","1","1").since(n.day)
+          draft_learn.save!
+          learn.created_at=Time.new("2020","1","1").since(n.day)
+          learn.save!
+        end
+      end
+    end
+    describe "いいねする" do
+      describe "自分の投稿にいいねする。" do
+        context "DraftLearn" do
+          before do
+            date=cuurent_user.draft_learns[0].created_at
+            d=[date.year,date.month,date.day]
+            @likeing_contents,@model=cuurent_user.likeing_type("DRAFTLEARN",d)
+          end
+          it "いいね数が増える" do
+            before_like_count=Like.all.count
+            Like.likeing_saves(@likeing_contents,@model,cuurent_user)
+            expect(before_like_count<Like.all.count).to be_truthy
+          end
+        end
+        context "Learn" do
+          before do
+            date=cuurent_user.learns[0].created_at
+            d=[date.year,date.month,date.day]
+            @likeing_contents,@model=cuurent_user.likeing_type("LEARN",d)
+          end
+          it "いいね数が増える" do
+            before_like_count=Like.all.count
+            Like.likeing_saves(@likeing_contents,@model,cuurent_user)
+            expect(before_like_count<Like.all.count).to be_truthy
+          end
+        end
+      end
+      context "他人の投稿にいいねする。" do
+        context "DraftLearn" do
+          before do
+            date=other_user.learns[0].created_at
+            d=[date.year,date.month,date.day]
+            @likeing_contents,@model=other_user.likeing_type("LEARN",d)
+          end
+          it "いいね数が増える" do
+            before_like_count=Like.all.count
+            Like.likeing_saves(@likeing_contents,@model,cuurent_user)
+            expect(before_like_count<Like.all.count).to be_truthy
+          end
+        end
+        context "Learn" do
+          before do
+            date=other_user.learns[0].created_at
+            d=[date.year,date.month,date.day]
+            @likeing_contents,@model=other_user.likeing_type("LEARN",d)
+          end
+          it "いいね数が増える" do
+            before_like_count=Like.all.count
+            Like.likeing_saves(@likeing_contents,@model,cuurent_user)
+            expect(before_like_count<Like.all.count).to be_truthy
+          end
+        end
+      end
+    end
+    describe "いいねを解除する" do
+      context "自分の投稿のいいねを解除する" do
+        context "DraftLearn" do
+          before do
+            date=cuurent_user.draft_learns[0].created_at
+            @d=[date.year,date.month,date.day]
+            @likeing_contents,@model=cuurent_user.likeing_type("DRAFTLEARN",@d)
+            Like.likeing_saves(@likeing_contents,@model,cuurent_user)
+          end
+          it "いいね数が減る" do
+            likeing_contents,model=cuurent_user.unlike_type("DRAFTLEARN",cuurent_user,@d)
+            before_like_count=Like.all.count
+            Like.likeing_destroys(likeing_contents,model)
+            expect(before_like_count>Like.all.count).to be_truthy
+          end
+        end
+        context "Learn" do
+          before do
+            date=cuurent_user.draft_learns[0].created_at
+            @d=[date.year,date.month,date.day]
+            @likeing_contents,@model=cuurent_user.likeing_type("LEARN",@d)
+            Like.likeing_saves(@likeing_contents,@model,cuurent_user)
+          end
+          it "いいね数が減る" do
+            likeing_contents,model=cuurent_user.unlike_type("LEARN",cuurent_user,@d)
+            before_like_count=Like.all.count
+            Like.likeing_destroys(likeing_contents,model)
+            expect(before_like_count>Like.all.count).to be_truthy
+          end
+        end
+      end
+      context "他のユーザの投稿のいいねを解除する" do
+        context "DraftLearn" do
+          before do
+            date=other_user.draft_learns[0].created_at
+            @d=[date.year,date.month,date.day]
+            @likeing_contents,@model=other_user.likeing_type("DRAFTLEARN",@d)
+            Like.likeing_saves(@likeing_contents,@model,cuurent_user)
+          end
+          it "いいね数が減る" do
+            likeing_contents,model=cuurent_user.unlike_type("DRAFTLEARN",other_user,@d)
+            before_like_count=Like.all.count
+            Like.likeing_destroys(likeing_contents,model)
+            expect(before_like_count>Like.all.count).to be_truthy
+          end
+        end
+        context "Learn" do
+          before do
+            date=other_user.draft_learns[0].created_at
+            @d=[date.year,date.month,date.day]
+            @likeing_contents,@model=other_user.likeing_type("LEARN",@d)
+            Like.likeing_saves(@likeing_contents,@model,cuurent_user)
+          end
+          it "いいね数が減る" do
+            likeing_contents,model=cuurent_user.unlike_type("LEARN",other_user,@d)
+            before_like_count=Like.all.count
+            Like.likeing_destroys(likeing_contents,model)
+            expect(before_like_count>Like.all.count).to be_truthy
+          end
+        end
+      end
+    end
+  end
 end

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,7 +1,4 @@
 require "test_helper"
 
 class LikeTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
 end


### PR DESCRIPTION
# What
・いいね機能の単体テストを書く。
・架空の投稿に対していいねできる。
・架空の投稿に対していいね解除。

# Why
・日付ごとにまとめた架空の投稿に対していいねできるかを確認する。
・日付ごとにまとめた架空の投稿に対していいねを解除できるかを確認する。
・ユーザは、一つの投稿に対して、一回、いいねできる事を確認する。