### PR TITLE
いいね機能APIテスト

### DIFF
--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -6,6 +6,12 @@ class Api::V1::LikesController < ApplicationController
 
   def create
     likeing_contents,model=@other_user.likeing_type(@type,@date)
+    return render json:{
+      data:{
+        message:"投稿が存在しません"
+      }
+    },status:401 if likeing_contents==[]
+
     Like.likeing_saves(likeing_contents,model,current_api_v1_user)
     item_id=likeing_contents[0][:draft_learn_id]? :learn_id : :draft_learn_id
     Notification.create(
@@ -24,6 +30,11 @@ class Api::V1::LikesController < ApplicationController
 
   def destroy
     likeing_contents,model=current_api_v1_user.unlike_type(@type,@other_user,@date)
+    return render json:{
+      data:{
+        message:"投稿が存在しません"
+      }
+    },status:401 if likeing_contents==[]
     Like.likeing_destroys(likeing_contents,model)
     item_id=likeing_contents[0][:draft_learn_id]? :learn_id : :draft_learn_id
      # いいねを解除されたら通知を削除。

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -10,7 +10,6 @@ class Like < ApplicationRecord
       like.save
     end
   end
-
   def self.likeing_destroys(likeing_contents,model)
     likeing_contents.each do |content|
       like=Like.find_by(model[:id]=>content.id)

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Likes", type: :request do
+  describe "GET /likes" do
+    it "works! (now write some real specs)" do
+      get likes_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -1,10 +1,150 @@
 require 'rails_helper'
 
 RSpec.describe "Likes", type: :request do
-  describe "GET /likes" do
-    it "works! (now write some real specs)" do
-      get likes_path
-      expect(response).to have_http_status(200)
+  let(:cuurent_user){FactoryBot.create(:test_user2)}
+  let(:other_user){FactoryBot.create(:test_user1)}
+  before do
+    [cuurent_user,other_user].each do |u|
+      5.times do |n|
+        draft_learn=DraftLearn.new({id: nil, title: "test#{n}", content: "content#{n}", subject: "test", time: 1, created_at: nil, updated_at: nil,user_id:u.id})
+        draft_learn.save!
+        learn = Learn.new({id: nil, title: "test#{n}", content: "content#{n}", subject: "", time: 1, created_at: nil, updated_at: nil,draft_learn_id:draft_learn.id,user_id:u.id})
+        subject=rand(4)
+        case subject
+          when 0
+            draft_learn.subject="プログラミング"
+            learn.subject="プログラミング"
+          when 1
+            draft_learn.subject="英語"
+            learn.subject="英語"
+          when 2
+            draft_learn.subject="資格"
+            learn.subject="資格"
+          when 3
+            draft_learn.subject="その他"
+            learn.subject="その他"
+        end
+        draft_learn.created_at=Time.new("2020","1","1").since(n.day)
+        draft_learn.save!
+        learn.created_at=Time.new("2020","1","1").since(n.day)
+        learn.save!
+      end
+    end
+    @params=auth_post cuurent_user, api_v1_user_session_path,
+    params:{
+      email:cuurent_user.email,
+      password:"000000"
+    }
+  end
+
+  describe "いいね機能" do
+    describe "いいねする" do
+      describe "POST api/v1/likes#create" do
+        context "他のユーザをいいねした場合" do
+          before do
+            @date=other_user.draft_learns[0].created_at
+          end
+          it "ステータスコード200が返ってくる" do
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:other_user.id},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+          it "いいね数が増える" do
+            before_like_count=Like.all.count
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:other_user.id},headers:@params[:headers])
+            expect(before_like_count<Like.all.count).to be_truthy
+          end
+        end
+        context "自分の投稿をいいねした場合"do
+          before do
+            @date=cuurent_user.draft_learns[0].created_at
+          end
+          it "ステータスコード200が返ってくる" do
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+          it "いいね数が増える" do
+            before_like_count=Like.all.count
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            expect(before_like_count<Like.all.count).to be_truthy
+          end
+          describe "投稿が存在しない場合" do
+            it "ステータスコード401が返ってる" do
+              post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:Time.now,other_user:cuurent_user.id},headers:@params[:headers])
+              expect(response.status).to eq 401
+            end
+            it "「投稿が存在しません」というメッセージを含む" do
+              post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:Time.now,other_user:cuurent_user.id},headers:@params[:headers])
+              res = JSON.parse(response.body)
+              expect(res['data']['message']).to eq "投稿が存在しません"
+            end
+          end
+        end
+        context "いいねした投稿をもう一度いいねした場合" do
+          before do
+            @date=cuurent_user.draft_learns[0].created_at
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+          end
+          it "ステータスコード200が返ってくる" do
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+          it "いいね数は変わらない" do
+            before_like_count=Like.all.count
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            expect(before_like_count==Like.all.count).to be_truthy
+          end
+        end
+      end
+    end
+    describe "いいねを解除する" do
+      describe "DELETE api/v1/likes#destroy" do
+        context "他のユーザをいいねを解除した場合" do
+          before do
+            @date=other_user.draft_learns[0].created_at
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:other_user.id},headers:@params[:headers])
+          end
+          it "ステータスコード200が返ってくる" do
+            delete(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:other_user.id},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+          it "いいね数は減る" do
+            before_like_count=Like.all.count
+            delete(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:other_user.id},headers:@params[:headers])
+            expect(before_like_count>Like.all.count).to be_truthy
+          end
+        end
+        context "自分の投稿をいいねを解除した場合"do
+          before do
+            @date=cuurent_user.draft_learns[0].created_at
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+          end
+          it "ステータスコード200が返ってくる" do
+            delete(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            expect(response.status).to eq 200
+          end
+          it "いいね数は減る" do
+            before_like_count=Like.all.count
+            delete(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            expect(before_like_count>Like.all.count).to be_truthy
+          end
+        end
+        context "いいねを解除した投稿に対して、もう一度いいねを解除した場合" do
+          before do
+            @date=cuurent_user.draft_learns[0].created_at
+            post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            delete(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+          end
+          it "ステータスコード401が返ってくる" do
+            delete(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            expect(response.status).to eq 401
+          end
+          it "「投稿が存在しません」というメッセージを含む" do
+            delete(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:cuurent_user.id},headers:@params[:headers])
+            res = JSON.parse(response.body)
+            expect(res['data']['message']).to eq "投稿が存在しません"
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -792,8 +792,23 @@ RSpec.describe "Users", type: :request do
                     end
                   end
                   # いいね機能単体テスト・APIテスト後にかく
-                  # context "type=LIKEと指定した場合" do
-                  # end
+                  context "type=LIKEと指定した場合" do
+                    before do
+                      @date=@other_user.draft_learns[0].created_at
+                      post(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:@other_user.id},headers:@params[:headers])
+                    end
+                    it "データが1個、存在する" do
+                      get(time_line_api_v1_user_path(user.id),params:{cuurent_page:1,type:"LIKE"})
+                      res=JSON.parse(response.body)
+                      expect(res['data']['timeLine'].length).to eq 1
+                    end
+                    it "いいね解除したら、データは空" do
+                      delete(api_v1_likes_path,params:{type:"DRAFTLEARN",date:@date,other_user:@other_user.id},headers:@params[:headers])
+                      get(time_line_api_v1_user_path(user.id),params:{cuurent_page:1,type:"LIKE"})
+                      res=JSON.parse(response.body)
+                      expect(res['data']['timeLine'].length).to eq 0
+                    end
+                  end
                 end
                 context "testuserをフォローしていない場合場合" do
                   it "testuserの投稿が存在しない" do


### PR DESCRIPTION
What
・いいね機能のAPIテストを書く。
・架空の投稿に対していいねできる。
・架空の投稿に対していいね解除。

Why
・日付ごとにまとめた架空の投稿に対していいねできるかを確認する。
・日付ごとにまとめた架空の投稿に対していいねを解除できるかを確認する。
・ユーザは、一つの投稿に対して、一回、いいねできる事を確認する。
