### PR TITLE
チャットルーム作成単体テスト

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::EntriesController < ApplicationController
       }
     },status:401  if !user.mutual_following?(other_user)
 
-    if Entry.entry_exist?(user,other_user)
+    if Entry.entry_not_exist?(user,other_user)
       room=Room.create()
       [
         {user_id:user.id,room_id:room.id},

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -3,7 +3,7 @@ class Entry < ApplicationRecord
   belongs_to :room
   scope :entry_room_grouping,->(user,other_user){where("user_id=? or user_id=? ",user.id,other_user.id).group(:room_id).count}
 
-  def self.entry_exist?(user,other_user)
+  def self.entry_not_exist?(user,other_user)
     self.entry_room_grouping(user,other_user).values.max.to_i < 2
   end
 

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :entry do
+    
+  end
+end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Entry, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -1,5 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe Entry, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:cuurent_user){FactoryBot.create(:test_user1)}
+  let(:other_user1){FactoryBot.create(:test_user2)}
+  describe "チャットルームを作成" do
+    before do
+      cuurent_user.follow(other_user1)
+      other_user1.follow(cuurent_user)
+    end
+    context "相互フォロー" do
+      context "チャットルームが存在しない場合" do
+        it "trueになる" do
+          expect(Entry.entry_not_exist?(cuurent_user,other_user1)).to  be_truthy
+        end
+        it "チャットルームを作成後、cuurent_user、other_user1のチャットルームが存在する" do
+          if Entry.entry_not_exist?(cuurent_user,other_user1)
+            room=Room.create()
+            [
+              {user_id:cuurent_user.id,room_id:room.id},
+              {user_id:other_user1.id,room_id:room.id}
+            ].each do |param|
+              entry=Entry.new(param)
+              entry.save
+            end
+            expect(expect(Entry.entry_not_exist?(cuurent_user,other_user1)).to  be_falsey)
+          end
+        end
+      end
+      context "チャットルームが存在する場合" do
+        before do
+          @room=Room.create()
+          [
+            {user_id:cuurent_user.id,room_id:@room.id},
+            {user_id:other_user1.id,room_id:@room.id}
+          ].each do |param|
+            entry=Entry.new(param)
+            entry.save
+          end
+        end
+        it "falseになる" do
+          expect(Entry.entry_not_exist?(cuurent_user,other_user1)).to  be_falsey
+        end
+        it "既存のチャットルームを取得する" do
+          room_id= Entry.get_room(cuurent_user,other_user1)
+          expect( room_id).to eq @room.id
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What
・チャットルーム作成機能の単体テストを書く。
・相互フォローしているユーザ同士のみチャットルーム作成可能。
・一人のユーザは、複数のチャットルームに属する事ができるが、重複してはならない。
・チャットルームには必ず2人のユーザが存在しなければならない。

# Why
・相互フォローしている事が、確認出来たユーザのみがチャットルームを作成ができる事を確認。
・既にチャットルームが作成されていた場合は、レコードを追加出来ないことを確認。
・チャットルームに2人のユーザが存在している事を確認。