### PR TITLE
既読機能APIテスト

### DIFF
--- a/app/controllers/api/v1/reads_controller.rb
+++ b/app/controllers/api/v1/reads_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::ReadsController < ApplicationController
     # 他のユーザのメッセージを受け取ったら、already_readをtrueに変更する。
     room=Room.find(params[:room_id])
     MessagesChannel.broadcast_to room,{message:read.message,read:read,name:"既読"}
-    render json:{data:{message:"OK"}},status:201
+    render json:{data:{message:"OK"}},status:200
    else
     render json:{data:{message:"更新に失敗しました。"}},status:401
    end

--- a/spec/requests/reads_spec.rb
+++ b/spec/requests/reads_spec.rb
@@ -1,10 +1,73 @@
 require 'rails_helper'
 
 RSpec.describe "Reads", type: :request do
-  describe "GET /reads" do
-    it "works! (now write some real specs)" do
-      get reads_path
-      expect(response).to have_http_status(200)
+  let(:cuurent_user){FactoryBot.create(:test_user1)}
+  let(:room){Room.create}
+  let(:message){Message.create(user_id:cuurent_user.id,room_id:room.id,message:"test")}
+  let(:read){Read.create(user_id:cuurent_user.id,message_id:message.id,room_id:room.id)}
+
+  describe "既読機能" do
+    context "更新に成功" do
+      it "ステータスコード200が返って来る" do
+        put(api_v1_user_room_read_path(cuurent_user.id,room.id,read.id),params:{room:{already_read:true}})
+        expect(response.status).to eq 200
+      end
+      it "already_readがtrueになっている" do
+        put(api_v1_user_room_read_path(cuurent_user.id,room.id,read.id),params:{room:{already_read:true}})
+        new_read= Read.find(read.id)
+        expect(new_read.already_read).to be_truthy
+      end
+    end
+    context "更新に失敗" do
+      it "user_idがnil" do
+        begin
+          put(api_v1_user_room_read_path(nil,room.id,read.id),params:{room:{already_read:true}})
+        rescue => e
+          expect(e.class).to eq ActionController::UrlGenerationError
+        end
+      end
+      it "user_idに紐づくユーザが存在しない" do
+        begin
+          put(api_v1_user_room_read_path(100,room.id,read.id),params:{room:{already_read:true}})
+        rescue => e
+         expect(e.class).to eq ActiveRecord::RecordNotFound
+        end
+      end
+      it "room_idがnil" do
+        begin
+          put(api_v1_user_room_read_path(cuurent_user.id,nil,read.id),params:{room:{already_read:true}})
+        rescue => e
+         expect(e.class).to eq ActionController::UrlGenerationError
+        end
+      end
+      it "room_idに紐づくチャットルームが存在しない" do
+        begin
+          put(api_v1_user_room_read_path(cuurent_user.id,100,read.id),params:{room:{already_read:true}})
+        rescue => e
+          expect(e.class).to eq ActiveRecord::RecordNotFound
+        end
+      end
+      it "idがnil" do
+        begin
+          put(api_v1_user_room_read_path(cuurent_user.id,nil,read.id),params:{room:{already_read:true}})
+        rescue => e
+         expect(e.class).to eq ActionController::UrlGenerationError
+        end
+      end
+      it "idに紐づくreadが存在しない" do
+        begin
+          put(api_v1_user_room_read_path(cuurent_user.id,100,read.id),params:{room:{already_read:true}})
+        rescue => e
+          expect(e.class).to eq ActiveRecord::RecordNotFound
+        end
+      end
+      it "paramsが空" do
+        begin
+          put(api_v1_user_room_read_path(cuurent_user.id,100,read.id),params:{})
+        rescue => e
+          expect(e.class).to eq ActionController::ParameterMissing
+        end
+      end
     end
   end
 end

--- a/spec/requests/reads_spec.rb
+++ b/spec/requests/reads_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Reads", type: :request do
+  describe "GET /reads" do
+    it "works! (now write some real specs)" do
+      get reads_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
# What
・既読機能のAPIを書く。
・メッセージを既読か未読かを確認
・DM機能
・メッセージ受信者側のユーザが入室したタイミングで「未読」から「既読」に更新する
・どちらもチャットルームに入室が確認できる場合は、常に「既読」に更新する。

# Why
・未読から既読に更新できるかを確認。
・存在しないreadがあった場合にエラーになるかを確認。
・どちらもチャットルームに入室が確認できる場合は、常に「既読」に更新できているかを確認。
・チャットルームに入室が確認できたタイミングで「既読」に更新されるかを確認。